### PR TITLE
Remove unused activity section subtitle field

### DIFF
--- a/src/components/profile-editor/ActivitiesSection.tsx
+++ b/src/components/profile-editor/ActivitiesSection.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { ImagesUploader } from "@/components/forms/ImagesUploader";

--- a/src/types/index.tsx
+++ b/src/types/index.tsx
@@ -382,7 +382,6 @@ export interface PortfolioData {
   nursery_state?: NurseryState;
   images_activities?: string[];
   activity_section_title?: string;
-  activity_section_subtitle?: string;
   activity_section_description?: string;
   teams?: TeamMember[];
   contact_info?: ContactInfo;


### PR DESCRIPTION
Deleted the activity_section_subtitle property from PortfolioData and cleaned up an unused Input import in ActivitiesSection.tsx to streamline the code.