### PR TITLE
Send complete portfolio data and improve image handling

### DIFF
--- a/src/app/[locale]/dashboard/center/center-data/page.tsx
+++ b/src/app/[locale]/dashboard/center/center-data/page.tsx
@@ -111,8 +111,9 @@ const ProfileEditor = () => {
 
   const handleSavePortfolio = () => {
     if (!hasChanges || !currentData) return;
-    const dirtyData = getDirtyData();
-    savePortfolio(dirtyData);
+    // Always send complete data, not just dirty fields
+    // This ensures arrays like services are sent completely
+    savePortfolio(currentData);
     // Update original data after save
     setOriginalData(currentData);
     setHasChanges(false);

--- a/src/services/dashboardApi.ts
+++ b/src/services/dashboardApi.ts
@@ -1001,16 +1001,18 @@ export const centerService = {
           return;
         }
         
-        // Skip ALL string values for image fields (empty strings or URLs)
-        // Only send File objects for images
-        if (typeof value === 'string' && 
+        // Skip ONLY empty strings for image fields
+        // Send existing URLs so backend can preserve them
+        if (typeof value === 'string' && value === '' &&
             (key.includes('image') || key.includes('background'))) {
-          if (value === '') {
-            console.log(`⏭️  Skipping empty image field for ${key}`);
-          } else {
-            console.log(`⏭️  Skipping existing image URL for ${key}:`, value.substring(0, 50));
-          }
+          console.log(`⏭️  Skipping empty image field for ${key}`);
           return;
+        }
+        
+        // Log when sending existing image URL
+        if (typeof value === 'string' && value !== '' &&
+            (key.includes('image') || key.includes('background'))) {
+          console.log(`🔗 Sending existing image URL for ${key}:`, value.substring(0, 50));
         }
         
         if (value instanceof File) {


### PR DESCRIPTION
Update the portfolio save logic to always send the complete data object instead of only dirty fields, ensuring arrays like services are fully transmitted. Refine image field handling in dashboardApi to skip only empty strings and allow existing image URLs to be sent, improving backend data consistency.